### PR TITLE
Fixed a bug firing keyup event twice on vue-todo input.

### DIFF
--- a/final/vue-todo/src/components/TodoInput.vue
+++ b/final/vue-todo/src/components/TodoInput.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="inputBox shadow">
-    <input type="text" v-model="newTodoItem" placeholder="Type what you have to do" v-on:keyup.enter="addTodo">
+    <input type="text" v-model="newTodoItem" placeholder="Type what you have to do" v-on:keypress.enter="addTodo">
     <span class="addContainer" v-on:click="addTodo">
       <i class="addBtn fas fa-plus" aria-hidden="true"></i>
     </span>


### PR DESCRIPTION
좋은 책 집필해 주셔서 감사합니다. 큰 도움이 되었습니다.
마이너한 부분이지만, 제 테스트 환경에서 사소한 이슈가 발견되어 간단한 pull request를 보내드립니다.
****
Fixed a bug firing keyup event twice on vue-todo input.
MacOSX - chrome 에서 한글입력후 엔터키 입력시 addTodo가 두번 호출되어 경고 modal이 보여지는 버그 수정.

### 내용
- Vue-todo app에서 한글로 내용 입력 후 엔터키를 눌렀을 때 keyup.enter 이벤트가 두 번 호출되는 이슈.

### 환경
- Mac OSX - High Sierra v10.13.2(17C88)
- Chrome 버전 66.0.3359.139(공식 빌드) (64비트)

### 기대결과
- Todo 목록에 입력된 내용 추가
- 인풋 항목 clear

### 실제결과
- Todo 목록에 입력된 내용 추가
- 인풋 항목 clear
- "할일을 입력하세요." 경고 모달 표시됨.

#### 해결책
- `keyup.enter` 이벤트를 `keypress.enter` 이벤트로 수정.